### PR TITLE
fix: Traefik dashboard entrypoint

### DIFF
--- a/argocd-apps/deploy/platform-apps/traefik.yaml
+++ b/argocd-apps/deploy/platform-apps/traefik.yaml
@@ -31,6 +31,9 @@ spec:
         ingressRoute:
           dashboard:
             enabled: true
+            entryPoints:
+              - web
+              - websecure
   destination:
     server: https://kubernetes.default.svc
     namespace: traefik


### PR DESCRIPTION
Fix entrypoint for the dashboard so that it's accessible

```
http://<host>/dashboard/ (HTTP)
https://<host>/dashboard/ (HTTPS)
```