### PR TITLE
fix: Grafana Ingress Route

### DIFF
--- a/argocd-apps/deploy/platform-apps/kube-prometheus-stack.yaml
+++ b/argocd-apps/deploy/platform-apps/kube-prometheus-stack.yaml
@@ -38,21 +38,6 @@ spec:
             server:
               root_url: "%(protocol)s://%(domain)s/grafana"
               serve_from_sub_path: true
-        extraObjects:
-          - apiVersion: traefik.io/v1alpha1
-            kind: IngressRoute
-            metadata:
-              name: grafana
-              namespace: monitoring
-            spec:
-              entryPoints:
-                - web
-              routes:
-                - match: Host(`grafana.localhost`) || PathPrefix(`/grafana`)
-                  kind: Rule
-                  services:
-                    - name: kube-prometheus-stack-grafana
-                      port: 80
         alertmanager:
           enabled: true
   destination:

--- a/k8s-manifests/grafana-ingressroute.yaml
+++ b/k8s-manifests/grafana-ingressroute.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`grafana.localhost`) || PathPrefix(`/grafana`)
+      kind: Rule
+      services:
+        - name: kube-prometheus-stack-grafana
+          port: 80


### PR DESCRIPTION
- Prometheus stack chart does not support extraObjects and Traefik ingressroute values
- Create a static manifest for now.