### PR TITLE
chore(fix): Steps root CA  and Grafana Redirect

### DIFF
--- a/argocd-apps/deploy/platform-apps/traefik.yaml
+++ b/argocd-apps/deploy/platform-apps/traefik.yaml
@@ -39,7 +39,6 @@ spec:
           stepca:
             acme:
               caServer: https://step-ca-step-certificates.step-ca.svc.cluster.local/acme/acme/directory
-              caBundle: /step-ca-certs/root_ca.crt
               storage: /data/acme.json
               httpChallenge:
                 entryPoint: web
@@ -53,6 +52,9 @@ spec:
           - name: step-ca-root-ca
             mountPath: /step-ca-certs
             type: configMap
+        env:
+          - name: LEGO_CA_CERTIFICATES
+            value: /step-ca-certs/root_ca.crt
   destination:
     server: https://kubernetes.default.svc
     namespace: traefik

--- a/argocd-apps/helm-charts/platform-apps/kube-prometheus-stack/templates/grafana-ingressroute.yaml
+++ b/argocd-apps/helm-charts/platform-apps/kube-prometheus-stack/templates/grafana-ingressroute.yaml
@@ -1,11 +1,37 @@
 ---
+# HTTP -> HTTPS redirect
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: grafana-http
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`grafana.{{ index .Values "kube-prometheus-stack" "grafana" "grafana.ini" "server" "domain" }}`)
+      kind: Rule
+      middlewares:
+        - name: redirect-to-https
+      services:
+        - name: kube-prometheus-stack-grafana
+          port: 80
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-https
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+---
+# HTTPS with TLS
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: grafana
 spec:
   entryPoints:
-    - web
     - websecure
   routes:
     - match: Host(`grafana.{{ index .Values "kube-prometheus-stack" "grafana" "grafana.ini" "server" "domain" }}`)


### PR DESCRIPTION
- Rollback the Lego env variable
- Add http-to-https redirect for grafana