### PR TITLE
chore(fix): traefik host route for api & dashboard

### DIFF
--- a/argocd-apps/deploy/platform-apps/traefik.yaml
+++ b/argocd-apps/deploy/platform-apps/traefik.yaml
@@ -31,9 +31,11 @@ spec:
         ingressRoute:
           dashboard:
             enabled: true
+            matchRule: Host(`traefik.lab.internal`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
             entryPoints:
-              - web
               - websecure
+            tls:
+              certResolver: stepca
         # ACME certificate resolver using step-ca as private CA
         certificatesResolvers:
           stepca:


### PR DESCRIPTION
- Add Host match for traefik dashboard and api uri paths. (Breaks grafana dashboard without Host match)