### PR TITLE
docs: Replace docker desktop with container desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,14 @@ colima status
    wsl --set-default-version 2
    ```
 
-2. **Install Podman Desktop** — download from [Podman Desktop for Windows](https://podman-desktop.io/downloads/windows) or use `winget`:
+2. **Install Docker CLI and Buildx** — required for VS Code Dev Containers to build and communicate with Podman Desktop:
+
+   ```powershell
+   winget install -e --id Docker.DockerCLI
+   winget install -e --id Docker.BuildX
+   ```
+
+3. **Install Podman Desktop** — download from [Podman Desktop for Windows](https://podman-desktop.io/downloads/windows) or use `winget`:
 
    ```powershell
    winget install -e --id RedHat.Podman-Desktop
@@ -129,7 +136,7 @@ colima status
    - Open Podman Desktop → **Settings** → **Preferences** → enable **Docker Compatibility**
    - Alternatively, from a terminal: `podman machine init` then `podman machine start`
 
-3. **Install Git for Windows** (provides `bash` needed by the devcontainer init script):
+4. **Install Git for Windows** (provides `bash` needed by the devcontainer init script):
 
    ```powershell
    winget install Git.Git

--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ colima status
    wsl --set-default-version 2
    ```
 
-2. **Install Container Desktop** — download the latest installer from [Container Desktop releases](https://github.com/container-desktop/container-desktop/releases) and run `ContainerDesktopInstaller.exe`.
+2. **Install Podman Desktop** — download from [Podman Desktop for Windows](https://podman-desktop.io/downloads/windows) or use `winget`:
 
-   > If Windows Defender SmartScreen blocks the installer, select **"More Info"** then **"Run Anyway"**.
+   ```powershell
+   winget install -e --id RedHat.Podman-Desktop
+   ```
 
 3. **Install Git for Windows** (provides `bash` needed by the devcontainer init script):
 
@@ -464,7 +466,7 @@ helm install my-app ./my-app
 
 - **Linux**: Ensure Docker service is running (`sudo systemctl start docker`) and your user is in the docker group (`sudo usermod -aG docker $USER`, then log out and back in)
 - **Mac**: Make sure Colima is running (`colima status`; start with `colima start`)
-- **Windows**: Make sure Container Desktop is running and WSL2 is enabled
+- **Windows**: Make sure Podman Desktop is running and WSL2 is enabled
 
 **Kind cluster won't create?**
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ colima status
    winget install -e --id RedHat.Podman-Desktop
    ```
 
+   After installation, enable Docker compatibility so VS Code Dev Containers can connect:
+   - Open Podman Desktop → **Settings** → **Preferences** → enable **Docker Compatibility**
+   - Alternatively, from a terminal: `podman machine init` then `podman machine start`
+
 3. **Install Git for Windows** (provides `bash` needed by the devcontainer init script):
 
    ```powershell

--- a/README.md
+++ b/README.md
@@ -119,13 +119,9 @@ colima status
    wsl --set-default-version 2
    ```
 
-2. **Install Docker Desktop** — download from [Docker Desktop for Windows](https://docs.docker.com/desktop/setup/install/windows-install/) or use `winget`:
+2. **Install Container Desktop** — download the latest installer from [Container Desktop releases](https://github.com/container-desktop/container-desktop/releases) and run `ContainerDesktopInstaller.exe`.
 
-   ```powershell
-   winget install Docker.DockerDesktop
-   ```
-
-   During setup, ensure **"Use WSL 2 based engine"** is checked (Settings > General).
+   > If Windows Defender SmartScreen blocks the installer, select **"More Info"** then **"Run Anyway"**.
 
 3. **Install Git for Windows** (provides `bash` needed by the devcontainer init script):
 
@@ -468,7 +464,7 @@ helm install my-app ./my-app
 
 - **Linux**: Ensure Docker service is running (`sudo systemctl start docker`) and your user is in the docker group (`sudo usermod -aG docker $USER`, then log out and back in)
 - **Mac**: Make sure Colima is running (`colima status`; start with `colima start`)
-- **Windows**: Make sure Docker Desktop is running and WSL2 is enabled
+- **Windows**: Make sure Container Desktop is running and WSL2 is enabled
 
 **Kind cluster won't create?**
 


### PR DESCRIPTION
## Summary
- Podman Desktop as the recommended Windows container runtime
- Added Docker CLI and Buildx as separate install steps (required for VS Code Dev Containers)
- Added post-install step to enable Docker compatibility mode in Podman Desktop

## References
- [Podman Desktop for Windows](https://podman-desktop.io/downloads/windows)
- [Docker.BuildX winget package](https://github.com/microsoft/winget-pkgs/issues/305503)
